### PR TITLE
Readme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you're testing in the Okta Preview environment, add a bool to the end of the 
 var okta = new OktaAPI("Your-Okta-API-Key", "your-domain", true);
 ```
 
-<your-domain> should only be __your Okta subdomain__ and should not include 'okta.com' as this will be appended automatically.
+Note that 'your-domain' should only be __your Okta subdomain__ and should not include 'okta.com' as this will be appended automatically.
 
 Note that all calls to the OktaAPI are returned in the following format:
 ```JSON

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ If you're testing in the Okta Preview environment, add a bool to the end of the 
 var okta = new OktaAPI("Your-Okta-API-Key", "your-domain", true);
 ```
 
+<your-domain> should only be __your Okta subdomain__ and should not include 'okta.com' as this will be appended automatically.
+
 Note that all calls to the OktaAPI are returned in the following format:
 ```JSON
 {


### PR DESCRIPTION
On creating a new Okta object the readme just states to enter 'your domain,' so I passed 'company.okta.com' (the full subdomain).  Doing this causes the request in NetworkAbstraction to generate a hostname of 'company.okta.com.okta.com' which causes Node to throw a very obscure SSL error on every request.  Specifying that okta.com should not be included should help other people avoid the same dumb mistake.
